### PR TITLE
Now more chars are allowed in FrontendError request payload and fixed…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 *.iml
 .idea
+.java-version

--- a/src/main/java/nl/_42/boot/logging/frontend/FrontendError.java
+++ b/src/main/java/nl/_42/boot/logging/frontend/FrontendError.java
@@ -1,9 +1,9 @@
 package nl._42.boot.logging.frontend;
 
+import javax.validation.constraints.Size;
+
 import lombok.Getter;
 import lombok.Setter;
-
-import javax.validation.constraints.Size;
 
 @Getter
 @Setter
@@ -12,13 +12,13 @@ public class FrontendError {
     /**
      * The URL on which the error occurred.
      */
-    @Size(max = 256)
+    @Size(max = 2_000)
     private String url;
 
     /**
      * The message of the error.
      */
-    @Size(max = 256)
+    @Size(max = 2_000)
     private String message;
 
     /**
@@ -26,13 +26,13 @@ public class FrontendError {
      * to detect which browser on which OS triggered
      * the error.
      */
-    @Size(max = 512)
+    @Size(max = 1024)
     private String userAgent;
 
     /**
      * The JavaScript Stackstrace of the error differs per browser
      */
-    @Size(max = 4096)
+    @Size(max = 10_000)
     private String stack;
 
 }

--- a/src/main/java/nl/_42/boot/logging/frontend/FrontendError.java
+++ b/src/main/java/nl/_42/boot/logging/frontend/FrontendError.java
@@ -26,13 +26,13 @@ public class FrontendError {
      * to detect which browser on which OS triggered
      * the error.
      */
-    @Size(max = 128)
+    @Size(max = 512)
     private String userAgent;
 
     /**
      * The JavaScript Stackstrace of the error differs per browser
      */
-    @Size(max = 512)
+    @Size(max = 4096)
     private String stack;
 
 }

--- a/src/main/java/nl/_42/boot/logging/frontend/FrontendLoggerController.java
+++ b/src/main/java/nl/_42/boot/logging/frontend/FrontendLoggerController.java
@@ -2,7 +2,6 @@ package nl._42.boot.logging.frontend;
 
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 
-import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
 import lombok.AllArgsConstructor;
@@ -20,7 +19,7 @@ public class FrontendLoggerController {
 
     @PostMapping("/error")
     @ResponseStatus(NO_CONTENT)
-    public void error(@Valid @RequestBody FrontendError error, HttpServletResponse response) {
+    public void error(@Valid @RequestBody FrontendError error) {
         logger.error(error);
     }
 

--- a/src/main/java/nl/_42/boot/logging/frontend/FrontendLoggerController.java
+++ b/src/main/java/nl/_42/boot/logging/frontend/FrontendLoggerController.java
@@ -1,11 +1,16 @@
 package nl._42.boot.logging.frontend;
 
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
+
 import lombok.AllArgsConstructor;
+
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-
-import javax.validation.Valid;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 @RequestMapping("/log")
 @AllArgsConstructor
@@ -14,7 +19,8 @@ public class FrontendLoggerController {
     private final FrontendLogger logger;
 
     @PostMapping("/error")
-    public void error(@Valid @RequestBody FrontendError error) {
+    @ResponseStatus(NO_CONTENT)
+    public void error(@Valid @RequestBody FrontendError error, HttpServletResponse response) {
         logger.error(error);
     }
 

--- a/src/test/java/nl/_42/boot/logging/frontend/FrontendLoggerControllerTest.java
+++ b/src/test/java/nl/_42/boot/logging/frontend/FrontendLoggerControllerTest.java
@@ -1,19 +1,21 @@
 package nl._42.boot.logging.frontend;
 
+import static org.junit.Assert.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
-import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class FrontendLoggerControllerTest extends AbstractWebIntegrationTest {
 
@@ -43,7 +45,7 @@ public class FrontendLoggerControllerTest extends AbstractWebIntegrationTest {
         frontendError.setUserAgent("Chrome on mac os");
 
         webClient.perform(post("/log/error").content(objectMapper.writeValueAsString(frontendError)))
-          .andExpect(status().isOk());
+          .andExpect(status().isNoContent());
 
         assertEquals(1, frontEndLoggerAppender.list.size());
 
@@ -64,7 +66,7 @@ public class FrontendLoggerControllerTest extends AbstractWebIntegrationTest {
         frontendError.setMessage("Big error in little China");
         frontendError.setUrl("https://www.42.nl");
         frontendError.setStack("Le big trace du stack");
-        frontendError.setUserAgent(StringUtils.repeat("a", 129));
+        frontendError.setUserAgent(StringUtils.repeat("a", 513));
 
         webClient.perform(post("/log/error").content(objectMapper.writeValueAsString(frontendError)))
           .andExpect(status().is4xxClientError());

--- a/src/test/java/nl/_42/boot/logging/frontend/FrontendLoggerControllerTest.java
+++ b/src/test/java/nl/_42/boot/logging/frontend/FrontendLoggerControllerTest.java
@@ -66,7 +66,7 @@ public class FrontendLoggerControllerTest extends AbstractWebIntegrationTest {
         frontendError.setMessage("Big error in little China");
         frontendError.setUrl("https://www.42.nl");
         frontendError.setStack("Le big trace du stack");
-        frontendError.setUserAgent(StringUtils.repeat("a", 513));
+        frontendError.setUserAgent(StringUtils.repeat("a", 1025));
 
         webClient.perform(post("/log/error").content(objectMapper.writeValueAsString(frontendError)))
           .andExpect(status().is4xxClientError());


### PR DESCRIPTION
… the controller from returning 404 for it's a spring mvc mapping that needs to result at least a view (here it's a rest endpoint that just returns no content).